### PR TITLE
Fix missing images when exporting to Day One

### DIFF
--- a/Source/RFDayOneExportController.m
+++ b/Source/RFDayOneExportController.m
@@ -105,17 +105,17 @@ static NSString* const kDayOneHelpPageURL = @"https://help.dayoneapp.com/en/arti
 		[args addObject:@"-a"];
 		for (NSString* url in photo_urls) {
 			NSURL* download_url = [NSURL URLWithString:url];
-            NSString* year = [[download_url URLByDeletingLastPathComponent] lastPathComponent];
-            NSString* year_folder = [uploads_folder stringByAppendingPathComponent:year];
-            NSString* filename = [download_url lastPathComponent];
-            NSString* file_path = [year_folder stringByAppendingPathComponent:filename];
-
+			NSString* year = [[download_url URLByDeletingLastPathComponent] lastPathComponent];
+			NSString* year_folder = [uploads_folder stringByAppendingPathComponent:year];
+			NSString* filename = [download_url lastPathComponent];
+			NSString* file_path = [year_folder stringByAppendingPathComponent:filename];
+			
 			if ([[NSFileManager defaultManager] fileExistsAtPath:file_path]) {
 				new_text = [self rewriteText:new_text replacingAttachmentURL:url];
 				[args addObject:file_path];
 			}
 		}
-
+		
 		[new_text writeToFile:path atomically:YES encoding:NSUTF8StringEncoding error:NULL];
 	}
 

--- a/Source/RFDayOneExportController.m
+++ b/Source/RFDayOneExportController.m
@@ -105,14 +105,17 @@ static NSString* const kDayOneHelpPageURL = @"https://help.dayoneapp.com/en/arti
 		[args addObject:@"-a"];
 		for (NSString* url in photo_urls) {
 			NSURL* download_url = [NSURL URLWithString:url];
-			NSString* filename = [[download_url pathComponents] lastObject];
-			NSString* download_path = [uploads_folder stringByAppendingPathComponent:filename];
-			if ([[NSFileManager defaultManager] fileExistsAtPath:download_path]) {
+            NSString* year = [[download_url URLByDeletingLastPathComponent] lastPathComponent];
+            NSString* year_folder = [uploads_folder stringByAppendingPathComponent:year];
+            NSString* filename = [download_url lastPathComponent];
+            NSString* file_path = [year_folder stringByAppendingPathComponent:filename];
+
+			if ([[NSFileManager defaultManager] fileExistsAtPath:file_path]) {
 				new_text = [self rewriteText:new_text replacingAttachmentURL:url];
-				[args addObject:download_path];
+				[args addObject:file_path];
 			}
 		}
-		
+
 		[new_text writeToFile:path atomically:YES encoding:NSUTF8StringEncoding error:NULL];
 	}
 


### PR DESCRIPTION
When exporting to Day One, Micro.blog for macOS creates the following structure in the file system: `uploads/YYYY/file.jpg`. 

Currently the year component isn't added to the file path, resulting in missing entries (it calls `/usr/local/bin/dayone2` passing `-a` but without a valid argument, causing  Day One to ignore the entry completely).

This Pull Request adds the year component to the file path.